### PR TITLE
Add deep-translator to requirements

### DIFF
--- a/requirements/full/requirements.txt
+++ b/requirements/full/requirements.txt
@@ -3,6 +3,7 @@ bitsandbytes==0.45.*
 colorama
 datasets
 duckduckgo_search==8.0.2
+deep-translator
 einops
 fastapi==0.112.4
 gradio==4.37.*


### PR DESCRIPTION
## Summary
- add `deep-translator` to `requirements/full/requirements.txt`
- install dependency so environment contains translator library

## Testing
- `pip install deep-translator`

------
https://chatgpt.com/codex/tasks/task_e_68586cda25e0832e90ac08d8e744c61c