### PR TITLE
Handle Matplotlib import failure

### DIFF
--- a/server.py
+++ b/server.py
@@ -29,9 +29,12 @@ with RequestBlocker():
     from modules import gradio_hijack
     import gradio as gr
 
-import matplotlib
-
-matplotlib.use('Agg')  # This fixes LaTeX rendering on some systems
+try:
+    import matplotlib
+    matplotlib.use('Agg')  # This fixes LaTeX rendering on some systems
+except Exception as e:
+    matplotlib = None
+    logger.warning(f"Matplotlib unavailable: {e}")
 
 import json
 import os


### PR DESCRIPTION
## Summary
- guard Matplotlib import so server startup doesn't fail if NumPy/Matplotlib aren't compatible

## Testing
- `python -m py_compile server.py && echo "py_compile succeeded"`


------
https://chatgpt.com/codex/tasks/task_e_68a22ef3ea20832ea6cc79df8d9ab9cb